### PR TITLE
Policy update

### DIFF
--- a/dss-demo-webapp/src/main/resources/IcelandPolicy.xml
+++ b/dss-demo-webapp/src/main/resources/IcelandPolicy.xml
@@ -4,35 +4,11 @@
 		signer's certificate and certificates used to validate certificate validity status services - CRLs, OCSP, and time-stamps).
 	</Description>
 	<ContainerConstraints>
-		<AcceptableContainerTypes Level="FAIL">
-			<Id>ASiC-S</Id>
-			<Id>ASiC-E</Id>
-		</AcceptableContainerTypes>
-<!-- 		<ZipCommentPresent Level="WARN" /> -->
-<!-- 		<AcceptableZipComment Level="WARN"> -->
-<!-- 			<Id>mimetype=application/vnd.etsi.asic-s+zip</Id> -->
-<!-- 			<Id>mimetype=application/vnd.etsi.asic-e+zip</Id> -->
-<!-- 		</AcceptableZipComment> -->
-		<MimeTypeFilePresent Level="FAIL" />
-		<AcceptableMimeTypeFileContent Level="WARN">
-			<Id>application/vnd.etsi.asic-s+zip</Id>
-			<Id>application/vnd.etsi.asic-e+zip</Id>
-		</AcceptableMimeTypeFileContent>
-		<ManifestFilePresent Level="FAIL" />
-		<SignedFilesPresent Level="FAIL" />
-		<AllFilesSigned Level="WARN" />
+		<AcceptableContainerTypes Level="FAIL" />
 	</ContainerConstraints>
-	<PDFAConstraints>
-		<!-- PDF/A only -->
-		<!--		<AcceptablePDFAProfiles Level="WARN">-->
-		<!--			<Id>PDF/A-2A</Id>-->
-		<!--			<Id>PDF/A-2B</Id>-->
-		<!--			<Id>PDF/A-2U</Id>-->
-		<!--		</AcceptablePDFAProfiles>-->
-		<!--		<PDFACompliant Level="WARN" />-->
-	</PDFAConstraints>
+	<PDFAConstraints />
 	<SignatureConstraints>
-		<StructuralValidation Level="WARN" />
+		<StructuralValidation Level="FAIL" />
 		<AcceptablePolicies Level="FAIL">
 			<Id>ANY_POLICY</Id>
 			<Id>NO_POLICY</Id>
@@ -48,49 +24,30 @@
 		<BasicSignatureConstraints>
 			<ReferenceDataExistence Level="FAIL" />
 			<ReferenceDataIntact Level="FAIL" />
-			<ManifestEntryObjectExistence Level="WARN" />
+			<ManifestEntryObjectExistence Level="FAIL" />
 			<SignatureIntact Level="FAIL" />
 			<SignatureDuplicated Level="FAIL" />
 			<ProspectiveCertificateChain Level="FAIL" />
 			<SignerInformationStore Level="FAIL" />
 			<ByteRange Level="FAIL" />
-			<ByteRangeCollision Level="WARN" />
+			<ByteRangeCollision Level="FAIL" />
 			<PdfSignatureDictionary Level="FAIL" />
 			<!-- Disable PDF modification checks -->
-			<!-- <PdfPageDifference Level="FAIL" />
-			<PdfAnnotationOverlap Level="WARN" />
-			<PdfVisualDifference Level="WARN" />
-			<DocMDP Level="WARN" />
-			<FieldMDP Level="WARN" />
-			<SigFieldLock Level="WARN" />
-			<UndefinedChanges Level="WARN" /> -->
-<!-- 			<TrustedServiceTypeIdentifier Level="WARN"> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/Svctype/CA/QC</Id> -->
-<!-- 			</TrustedServiceTypeIdentifier> -->
-<!-- 			<TrustedServiceStatus Level="FAIL"> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/undersupervision</Id> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/accredited</Id> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/supervisionincessation</Id> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/granted</Id> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/withdrawn</Id> -->
-<!-- 			</TrustedServiceStatus> -->
 			<SigningCertificate>
 				<Recognition Level="FAIL" />
 				<Signature Level="FAIL" />
 				<NotExpired Level="FAIL" />
-				<AuthorityInfoAccessPresent Level="WARN" />
-				<RevocationInfoAccessPresent Level="WARN" />
+				<AuthorityInfoAccessPresent Level="INFORM" />
+				<RevocationInfoAccessPresent Level="INFORM" />
 				<RevocationDataAvailable Level="FAIL" />
 				<AcceptableRevocationDataFound Level="FAIL" />
-				<CRLNextUpdatePresent Level="WARN" />
-<!--				<OCSPNextUpdatePresent Level="WARN" /> -->
 				<RevocationFreshness Level="FAIL" Unit="HOURS" Value="24" />
-				<KeyUsage Level="WARN">
+				<KeyUsage Level="FAIL">
 					<Id>nonRepudiation</Id>
 				</KeyUsage>
-				<PolicyTree Level="WARN" />
-				<NameConstraints Level="WARN" />
-				<SupportedCriticalExtensions Level="WARN">
+				<PolicyTree Level="FAIL" />
+				<NameConstraints Level="FAIL" />
+				<SupportedCriticalExtensions Level="FAIL">
 					<Id>2.5.29.15</Id> <!-- keyUsage -->
 					<Id>2.5.29.32</Id> <!-- certificatePolicies -->
 					<Id>2.5.29.17</Id> <!-- subjectAlternativeName -->
@@ -106,16 +63,11 @@
 				<ForbiddenExtensions Level="FAIL">
 					<Id>1.3.6.1.5.5.7.48.1.5</Id> <!-- ocsp_noCheck -->
 				</ForbiddenExtensions>
-				<SerialNumberPresent Level="WARN" />
+				<SerialNumberPresent Level="FAIL" />
 				<NotRevoked Level="FAIL" />
 				<NotOnHold Level="FAIL" />
 				<RevocationIssuerNotExpired Level="FAIL" />
-				<NotSelfSigned Level="WARN" />
-<!--				<QcCompliance Level="WARN" /> -->
-<!--				<QcSSCD Level="WARN" /> -->
-<!-- 				<QcLegislationCountryCodes Level="WARN" /> -->
-<!-- 				<IssuedToNaturalPerson Level="INFORM" /> -->
-<!-- 				<IssuedToLegalPerson Level="INFORM" /> -->
+				<NotSelfSigned Level="FAIL" />
 				<UsePseudonym Level="INFORM" />
 				<Cryptographic Level="FAIL">
 					<AcceptableEncryptionAlgo>
@@ -193,17 +145,15 @@
 				<NotExpired Level="FAIL" />
 				<RevocationDataAvailable Level="FAIL" />
 				<AcceptableRevocationDataFound Level="FAIL" />
-				<CRLNextUpdatePresent Level="WARN" />
-<!--				<OCSPNextUpdatePresent Level="WARN" /> -->
 				<RevocationFreshness Level="IGNORE" Unit="HOURS" Value="24" />
 				<CA Level="FAIL" />
 				<MaxPathLength Level="FAIL" />
 				<KeyUsage Level="FAIL">
 					<Id>keyCertSign</Id>
 				</KeyUsage>
-				<PolicyTree Level="WARN" />
-				<NameConstraints Level="WARN" />
-				<SupportedCriticalExtensions Level="WARN">
+				<PolicyTree Level="FAIL" />
+				<NameConstraints Level="FAIL" />
+				<SupportedCriticalExtensions Level="FAIL">
 					<Id>2.5.29.15</Id> <!-- keyUsage -->
 					<Id>2.5.29.32</Id> <!-- certificatePolicies -->
 					<Id>2.5.29.17</Id> <!-- subjectAlternativeName -->
@@ -297,27 +247,17 @@
 		</BasicSignatureConstraints>
 		<SignedAttributes>
 			<SigningCertificatePresent Level="FAIL" />
-			<UnicitySigningCertificate Level="WARN" />
-			<SigningCertificateRefersCertificateChain Level="WARN" />
-			<SigningCertificateDigestAlgorithm Level="WARN" />
+			<SigningCertificateRefersCertificateChain Level="FAIL" />
+			<SigningCertificateDigestAlgorithm Level="FAIL" />
 			<CertDigestPresent Level="FAIL" />
 			<CertDigestMatch Level="FAIL" />
-			<IssuerSerialMatch Level="WARN" />
-			<KeyIdentifierMatch Level="WARN" />
+			<IssuerSerialMatch Level="FAIL" />
+			<KeyIdentifierMatch Level="FAIL" />
 			<SigningTime Level="FAIL" />
 			<MessageDigestOrSignedPropertiesPresent Level="FAIL" />
-			<EllipticCurveKeySize Level="WARN" />
-<!--		<ContentType Level="FAIL" value="1.2.840.113549.1.7.1" /> -->
-<!--		<ContentHints Level="FAIL" value="*" /> -->
-<!--		<CommitmentTypeIndication Level="FAIL"> -->
-<!--				<Id>1.2.840.113549.1.9.16.6.5</Id> -->
-<!--		</CommitmentTypeIndication> -->
-<!--		<SignerLocation Level="FAIL" /> -->
-<!--		<ContentTimeStamp Level="FAIL" /> -->
+			<EllipticCurveKeySize Level="FAIL" />
 		</SignedAttributes>
-		<UnsignedAttributes>
-<!--		<CounterSignature Level="IGNORE" /> check presence -->
-		</UnsignedAttributes>
+		<UnsignedAttributes />
 	</SignatureConstraints>
 	<CounterSignatureConstraints>
 		<BasicSignatureConstraints>
@@ -326,33 +266,21 @@
 			<SignatureIntact Level="FAIL" />
 			<SignatureDuplicated Level="FAIL" />
 			<ProspectiveCertificateChain Level="FAIL" />
-<!-- 			<TrustedServiceTypeIdentifier Level="WARN"> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/Svctype/CA/QC</Id> -->
-<!-- 			</TrustedServiceTypeIdentifier> -->
-<!-- 			<TrustedServiceStatus Level="FAIL"> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/undersupervision</Id> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/accredited</Id> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/supervisionincessation</Id> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/granted</Id> -->
-<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/withdrawn</Id> -->
-<!-- 			</TrustedServiceStatus> -->
 			<SigningCertificate>
 				<Recognition Level="FAIL" />
 				<Signature Level="FAIL" />
 				<NotExpired Level="FAIL" />
-				<AuthorityInfoAccessPresent Level="WARN" />
-				<RevocationInfoAccessPresent Level="WARN" />
+				<AuthorityInfoAccessPresent Level="INFORM" />
+				<RevocationInfoAccessPresent Level="INFORM" />
 				<RevocationDataAvailable Level="FAIL" />
 				<AcceptableRevocationDataFound Level="FAIL" />
-				<CRLNextUpdatePresent Level="WARN" />
-<!--				<OCSPNextUpdatePresent Level="WARN" /> -->
 				<RevocationFreshness Level="FAIL" Unit="HOURS" Value="24" />
-				<KeyUsage Level="WARN">
+				<KeyUsage Level="FAIL">
 					<Id>nonRepudiation</Id>
 				</KeyUsage>
-				<PolicyTree Level="WARN" />
-				<NameConstraints Level="WARN" />
-				<SupportedCriticalExtensions Level="WARN">
+				<PolicyTree Level="FAIL" />
+				<NameConstraints Level="FAIL" />
+				<SupportedCriticalExtensions Level="FAIL">
 					<Id>2.5.29.15</Id> <!-- keyUsage -->
 					<Id>2.5.29.32</Id> <!-- certificatePolicies -->
 					<Id>2.5.29.17</Id> <!-- subjectAlternativeName -->
@@ -368,14 +296,10 @@
 				<ForbiddenExtensions Level="FAIL">
 					<Id>1.3.6.1.5.5.7.48.1.5</Id> <!-- ocsp_noCheck -->
 				</ForbiddenExtensions>
-				<SerialNumberPresent Level="WARN" />
+				<SerialNumberPresent Level="FAIL" />
 				<NotRevoked Level="FAIL" />
 				<NotOnHold Level="FAIL" />
-				<NotSelfSigned Level="WARN" />
-<!--				<QcCompliance Level="WARN" /> -->
-<!--				<QcSSCD Level="WARN" /> -->
-<!-- 				<IssuedToNaturalPerson Level="INFORM" /> -->
-<!-- 				<IssuedToLegalPerson Level="INFORM" /> -->
+				<NotSelfSigned Level="FAIL" />
 				<UsePseudonym Level="INFORM" />
 				<Cryptographic />
 			</SigningCertificate>
@@ -384,17 +308,15 @@
 				<NotExpired Level="FAIL" />
 				<RevocationDataAvailable Level="FAIL" />
 				<AcceptableRevocationDataFound Level="FAIL" />
-				<CRLNextUpdatePresent Level="WARN" />
-<!--				<OCSPNextUpdatePresent Level="WARN" /> -->
 				<RevocationFreshness Level="IGNORE" Unit="HOURS" Value="24" />
 				<CA Level="FAIL" />
 				<MaxPathLength Level="FAIL" />
 				<KeyUsage Level="FAIL">
 					<Id>keyCertSign</Id>
 				</KeyUsage>
-				<PolicyTree Level="WARN" />
-				<NameConstraints Level="WARN" />
-				<SupportedCriticalExtensions Level="WARN">
+				<PolicyTree Level="FAIL" />
+				<NameConstraints Level="FAIL" />
+				<SupportedCriticalExtensions Level="FAIL">
 					<Id>2.5.29.15</Id> <!-- keyUsage -->
 					<Id>2.5.29.32</Id> <!-- certificatePolicies -->
 					<Id>2.5.29.17</Id> <!-- subjectAlternativeName -->
@@ -418,49 +340,31 @@
 		</BasicSignatureConstraints>
 		<SignedAttributes>
 			<SigningCertificatePresent Level="FAIL" />
-			<UnicitySigningCertificate Level="WARN" />
-			<SigningCertificateRefersCertificateChain Level="WARN" />
-			<SigningCertificateDigestAlgorithm Level="WARN" />
+			<SigningCertificateRefersCertificateChain Level="FAIL" />
+			<SigningCertificateDigestAlgorithm Level="FAIL" />
 			<CertDigestPresent Level="FAIL" />
 			<CertDigestMatch Level="FAIL" />
-			<IssuerSerialMatch Level="WARN" />
-			<KeyIdentifierMatch Level="WARN" />
+			<IssuerSerialMatch Level="FAIL" />
+			<KeyIdentifierMatch Level="FAIL" />
 			<SigningTime Level="FAIL" />
 			<MessageDigestOrSignedPropertiesPresent Level="FAIL" />
-			<EllipticCurveKeySize Level="WARN" />
-<!--		<ContentType Level="FAIL" value="1.2.840.113549.1.7.1" />
-			<ContentHints Level="FAIL" value="*" />
-			<CommitmentTypeIndication Level="FAIL">
-				<Id>1.2.840.113549.1.9.16.6.1</Id>
-				<Id>1.2.840.113549.1.9.16.6.4</Id>
-				<Id>1.2.840.113549.1.9.16.6.5</Id>
-				<Id>1.2.840.113549.1.9.16.6.6</Id>
-			</CommitmentTypeIndication>
-			<SignerLocation Level="FAIL" />
-			<ContentTimeStamp Level="FAIL" /> -->
+			<EllipticCurveKeySize Level="FAIL" />
 		</SignedAttributes>
 	</CounterSignatureConstraints>
 	<Timestamp>
 		<TimestampDelay Level="FAIL" Unit="SECONDS" Value="120" />
 		<RevocationTimeAgainstBestSignatureTime	Level="FAIL" />
 		<BestSignatureTimeBeforeExpirationDateOfSigningCertificate Level="FAIL" />
-		<Coherence Level="WARN" />
+		<Coherence Level="FAIL" />
 		<BasicSignatureConstraints>
 			<ReferenceDataExistence Level="FAIL" />
 			<ReferenceDataIntact Level="FAIL" />
 			<SignatureIntact Level="FAIL" />
 			<ProspectiveCertificateChain Level="FAIL" />
 			<ByteRange Level="FAIL" />
-			<ByteRangeCollision Level="WARN" />
+			<ByteRangeCollision Level="FAIL" />
 			<PdfSignatureDictionary Level="FAIL" />
 			<!-- Disable PDF modification checks -->
-			<!-- <PdfPageDifference Level="FAIL" />
-			<PdfAnnotationOverlap Level="WARN" />
-			<PdfVisualDifference Level="WARN" />
-			<DocMDP Level="WARN" />
-			<FieldMDP Level="WARN" />
-			<SigFieldLock Level="WARN" />
-			<UndefinedChanges Level="WARN" /> -->
 			<TrustedServiceTypeIdentifier Level="FAIL">
 				<Id>http://uri.etsi.org/TrstSvc/Svctype/TSA/QTST</Id>
 			</TrustedServiceTypeIdentifier>
@@ -478,15 +382,13 @@
 				<NotExpired Level="FAIL" />
 				<RevocationDataAvailable Level="FAIL" />
 				<AcceptableRevocationDataFound Level="FAIL" />
-				<CRLNextUpdatePresent Level="WARN" />
-<!--				<OCSPNextUpdatePresent Level="WARN" /> -->
 				<RevocationFreshness Level="IGNORE" Unit="HOURS" Value="24" />
 				<ExtendedKeyUsage Level="FAIL">
 					<Id>timeStamping</Id>
 				</ExtendedKeyUsage>
-				<PolicyTree Level="WARN" />
-				<NameConstraints Level="WARN" />
-				<SupportedCriticalExtensions Level="WARN">
+				<PolicyTree Level="FAIL" />
+				<NameConstraints Level="FAIL" />
+				<SupportedCriticalExtensions Level="FAIL">
 					<Id>2.5.29.15</Id> <!-- keyUsage -->
 					<Id>2.5.29.32</Id> <!-- certificatePolicies -->
 					<Id>2.5.29.17</Id> <!-- subjectAlternativeName -->
@@ -510,19 +412,17 @@
 			<CACertificate>
 				<Signature Level="FAIL" />
 				<NotExpired Level="FAIL" />
-				<RevocationDataAvailable Level="WARN" />
-				<AcceptableRevocationDataFound Level="WARN" />
-				<CRLNextUpdatePresent Level="WARN" />
-<!--				<OCSPNextUpdatePresent Level="WARN" /> -->
+				<RevocationDataAvailable Level="FAIL" />
+				<AcceptableRevocationDataFound Level="FAIL" />
 				<RevocationFreshness Level="IGNORE" Unit="HOURS" Value="24" />
 				<CA Level="FAIL" />
 				<MaxPathLength Level="FAIL" />
 				<KeyUsage Level="FAIL">
 					<Id>keyCertSign</Id>
 				</KeyUsage>
-				<PolicyTree Level="WARN" />
-				<NameConstraints Level="WARN" />
-				<SupportedCriticalExtensions Level="WARN">
+				<PolicyTree Level="FAIL" />
+				<NameConstraints Level="FAIL" />
+				<SupportedCriticalExtensions Level="FAIL">
 					<Id>2.5.29.15</Id> <!-- keyUsage -->
 					<Id>2.5.29.32</Id> <!-- certificatePolicies -->
 					<Id>2.5.29.17</Id> <!-- subjectAlternativeName -->
@@ -545,19 +445,17 @@
 			<Cryptographic />
 		</BasicSignatureConstraints>
 		<SignedAttributes>
-			<SigningCertificatePresent Level="WARN" />
-			<!-- <UnicitySigningCertificate Level="WARN" /> RFC 5816 -->
-			<SigningCertificateRefersCertificateChain Level="WARN" />
-			<!-- <SigningCertificateDigestAlgorithm Level="WARN" /> -->
-			<CertDigestPresent Level="WARN" />
-			<IssuerSerialMatch Level="WARN" />
+			<SigningCertificatePresent Level="FAIL" />
+			<SigningCertificateRefersCertificateChain Level="FAIL" />
+			<CertDigestPresent Level="FAIL" />
+			<IssuerSerialMatch Level="FAIL" />
 		</SignedAttributes>
-		<TSAGeneralNameContentMatch Level="WARN" />
+		<TSAGeneralNameContentMatch Level="FAIL" />
 	</Timestamp>
 	<Revocation>
         <UnknownStatus Level="FAIL" />
 		<OCSPResponderIdMatch Level="FAIL" />
-        <SelfIssuedOCSP Level="WARN" />
+        <SelfIssuedOCSP Level="FAIL" />
 		<BasicSignatureConstraints>
 			<ReferenceDataExistence Level="FAIL" />
 			<ReferenceDataIntact Level="FAIL" />
@@ -569,12 +467,10 @@
 				<NotExpired Level="FAIL" />
 				<RevocationDataAvailable Level="FAIL" />
 				<AcceptableRevocationDataFound Level="FAIL" />
-				<CRLNextUpdatePresent Level="WARN" />
-<!--				<OCSPNextUpdatePresent Level="WARN" /> -->
 				<RevocationFreshness Level="IGNORE" Unit="HOURS" Value="24" />
-				<PolicyTree Level="WARN" />
-				<NameConstraints Level="WARN" />
-				<SupportedCriticalExtensions Level="WARN">
+				<PolicyTree Level="FAIL" />
+				<NameConstraints Level="FAIL" />
+				<SupportedCriticalExtensions Level="FAIL">
 					<Id>2.5.29.15</Id> <!-- keyUsage -->
 					<Id>2.5.29.32</Id> <!-- certificatePolicies -->
 					<Id>2.5.29.17</Id> <!-- subjectAlternativeName -->
@@ -590,24 +486,23 @@
 				</SupportedCriticalExtensions>
 				<NotRevoked Level="FAIL" />
 				<NotOnHold Level="FAIL" />
+				<NotSelfSigned Level="WARN" />
 				<Cryptographic />
 			</SigningCertificate>
 			<CACertificate>
 				<Signature Level="FAIL" />
 				<NotExpired Level="FAIL" />
-				<RevocationDataAvailable Level="WARN" />
-				<AcceptableRevocationDataFound Level="WARN" />
-				<CRLNextUpdatePresent Level="WARN" />
-<!--				<OCSPNextUpdatePresent Level="WARN" /> -->
+				<RevocationDataAvailable Level="FAIL" />
+				<AcceptableRevocationDataFound Level="FAIL" />
 				<RevocationFreshness Level="IGNORE" Unit="HOURS" Value="24" />
 				<CA Level="FAIL" />
 				<MaxPathLength Level="FAIL" />
 				<KeyUsage Level="FAIL">
 					<Id>keyCertSign</Id>
 				</KeyUsage>
-				<PolicyTree Level="WARN" />
-				<NameConstraints Level="WARN" />
-				<SupportedCriticalExtensions Level="WARN">
+				<PolicyTree Level="FAIL" />
+				<NameConstraints Level="FAIL" />
+				<SupportedCriticalExtensions Level="FAIL">
 					<Id>2.5.29.15</Id> <!-- keyUsage -->
 					<Id>2.5.29.32</Id> <!-- certificatePolicies -->
 					<Id>2.5.29.17</Id> <!-- subjectAlternativeName -->

--- a/dss-demo-webapp/src/main/resources/IcelandPolicy.xml
+++ b/dss-demo-webapp/src/main/resources/IcelandPolicy.xml
@@ -352,7 +352,6 @@
 		</SignedAttributes>
 	</CounterSignatureConstraints>
 	<Timestamp>
-		<TimestampDelay Level="FAIL" Unit="SECONDS" Value="120" />
 		<RevocationTimeAgainstBestSignatureTime	Level="FAIL" />
 		<BestSignatureTimeBeforeExpirationDateOfSigningCertificate Level="FAIL" />
 		<Coherence Level="FAIL" />

--- a/dss-demo-webapp/src/main/resources/IcelandPolicy.xml
+++ b/dss-demo-webapp/src/main/resources/IcelandPolicy.xml
@@ -99,11 +99,11 @@
 						<Algo>RIPEMD160</Algo>
 						<Algo>WHIRLPOOL</Algo>
 					</AcceptableDigestAlgo>
-					<AlgoExpirationDate Level="FAIL" Format="yyyy" UpdateDate="2022" LevelAfterUpdate="WARN">
+					<AlgoExpirationDate Level="FAIL" Format="yyyy" UpdateDate="2016" LevelAfterUpdate="WARN">
 						<!-- Digest algorithms -->
 						<!--		<Algo Date="2005">MD2</Algo> 		Not referenced in ETSI/SOGIS -->
 						<Algo Date="2005">MD5</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.1.1 -->
-						<Algo Date="2026">SHA1</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.0.0 -->
+						<Algo Date="2017">SHA1</Algo> <!-- Modified for Digital Iceland to return a warning on SHA-1 usage -->
 						<Algo Date="2026">SHA224</Algo> <!-- ETSI 119 312 V1.4.2 -->
 						<Algo Date="2029">SHA256</Algo> <!-- ETSI 119 312 V1.4.2 -->
 						<Algo Date="2029">SHA384</Algo> <!-- ETSI 119 312 V1.4.2 -->
@@ -201,11 +201,11 @@
 						<Algo>RIPEMD160</Algo>
 						<Algo>WHIRLPOOL</Algo>
 					</AcceptableDigestAlgo>
-					<AlgoExpirationDate Level="FAIL" Format="yyyy" UpdateDate="2022" LevelAfterUpdate="WARN">
+					<AlgoExpirationDate Level="FAIL" Format="yyyy" UpdateDate="2016" LevelAfterUpdate="WARN">
 						<!-- Digest algorithms -->
 						<!--		<Algo Date="2005">MD2</Algo> 		Not referenced in ETSI/SOGIS -->
 						<Algo Date="2005">MD5</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.1.1 -->
-						<Algo Date="2026">SHA1</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.0.0 -->
+						<Algo Date="2017">SHA1</Algo> <!-- Modified for Digital Iceland to return a warning on SHA-1 usage -->
 						<Algo Date="2026">SHA224</Algo> <!-- ETSI 119 312 V1.4.2 -->
 						<Algo Date="2029">SHA256</Algo> <!-- ETSI 119 312 V1.4.2 -->
 						<Algo Date="2029">SHA384</Algo> <!-- ETSI 119 312 V1.4.2 -->


### PR DESCRIPTION
Hello,

The following modifications have been made in the validation policy:

**1) Modified WARN level constraints to ensure a "strict" processing:**

- **ContainerConstraints.AcceptableContainerTypes** contains an empty list in order to invalidate all ASiC containers (only XAdES and PAdES signatures are allowed);
- **PDFAConstraints** has been made empty (PDF/A validation is not used);
- **StructuralValidation** is enforced to FAIL level. This constraints validates a XAdES signature to the XAdES XSD conformance (not used directly in PDFs);
- **ManifestEntryObjectExistence**  isenforced to FAIL level. Verified whether original documents have been provided to the validation when verifying a XAdES signing a manifest;
- **ByteRangeCollision** is enforced to FAIL level. Verifies whether a PDF document has an ordered revision structure;
- **AuthorityInfoAccessPresent** and **RevocationInfoAccessPresent** are changed to INFORM level. Both constraints verify presence of a URI to extract its CA issuers or a revocation data. The failure of the check should not invalidate the signature directly, as all required information maybe present in a signature itself. However, the information could be useful when a validator does not have sufficient data to validate a certificate succesfully.
- **CRLNextUpdatePresent** constraint has been removed. The constraint verifies a presence of CRL nextUpdate field. As an enforced value (24 hours) is used in a Revocation Freshness Check, the CRL nextUpdate value is not used directly. The failiure of the check should not invalidate the signature.
- **KeyUsage** is enforced to FAIL level. This check is used to ensure the signature is created with a certificate with a "nonRepudiation" key usage.
- **PolicyTree, NameConstraints, SupportedCriticalExtensions** and **SerialNumberPresent** are enforced to FAIL level. The constraints verify a certificate conformance to RFC 5280.
- **NotSelfSigned** is enforced to FAIL level for signing-certificates. The check verifies that the certificate is not a self-signed certificate. Please note, that the value of the check is set to WARN for timestamps and revocation data, and there is no standard directyl forbidding this behavior;
- **UnicitySigningCertificate** has been removed. Constraint verifies whether only one certificate is referenced within a corresponding signing-certificate(-v2) signed attribute. This is not required by ETSI standard (e.g. complete certificate chain may be present).
- **SigningCertificateRefersCertificateChain** is enforced to FAIL level. Constraint verifies that all certificates present within a corresponding signing-certificate(-v2) signed attribute are the certificates from a certificate chain. This is the mandatory requirement in ETSI standard.
- **SigningCertificateDigestAlgorithm** is enforced to FAIL level. Constraint verifies that the signing-certificate(-v2) signed attribute contains references created with an acceptable digest algorithm (uses the cryptographic constraints defined in the policy);
- **IssuerSerialMatch** and **KeyIdentifierMatch** are enforced to FAIL level. Constraint verifies that the signing-certificate(-v2) signed attribute's fields match corresponding values in a signing-certificate;
- **EllipticCurveKeySize** is enforced to FAIL level. Constraint verifies that the elliptic curve used to sign the signature matches the key size of the signing-certificate;
- **Timestamp.Coherence** is enforced to FAIL level. Constraint verifies the order of timestamps within a signature;
- **Timestamp.SigningCertificatePresent** is enforced to FAIL level. Constraint verifies that the time-stamp contains a reference to its signing-certificate;
- **Revocation.SelfIssuedOCSP** is enforced to FAIL level. Constraint identifies an error in CA PKI, when a certificate issuing an OCSP response is present in a certificate chain used to issue an OCSP token for itself;
- **eIDAS** are kept at WARN level. It can be too strict to reject a signature in case of a Trusted List temporary inavailability.

Additionally, all commented constraints have been removed.

**2) Removed TimestampDelay constraint.**

**3) Adapted cryptographic constraints in order to return a WARN message for certificates created with SHA-1 digest algorithm.**

Please do not hesitate to raise your concerns or questions about any modification that has been made.

I remain at your disposal.

Kind regards,
Aleksandr.